### PR TITLE
Specify proper C standard for windows build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ verthashincludes = [
 
 verthash_module = Extension('verthash',
                             sources=verthashsources+['verthashmodule.c'],
+                            extra_compile_args=['-std=c99'],
                             include_dirs=verthashincludes)
 
 setup(name = 'verthash',


### PR DESCRIPTION
Without this MinGW GCC on Windows complains about for loop definitions outside C99 mode.